### PR TITLE
Improve performance by preallocating the output buffer

### DIFF
--- a/cobs.go
+++ b/cobs.go
@@ -35,7 +35,9 @@ func TrimNull(p []byte) []byte {
 }
 
 // Encode a null-terminated slice of bytes to a cobs frame
-func Encode(p []byte) (b []byte) {
+func Encode(p []byte) []byte {
+	// preallocate output buffer with estimated size
+	b := make([]byte, 0, EncodedSize(len(p)))
 	var x [0xff]byte
 	x[0] = 1
 	for _, v := range p {
@@ -58,7 +60,9 @@ func Encode(p []byte) (b []byte) {
 }
 
 // Decode a cobs frame to a null-terminated slice of bytes
-func Decode(p []byte) (b []byte) {
+func Decode(p []byte) []byte {
+	// preallocate output buffer, data will be smaller than input
+	b := make([]byte, 0, len(p))
 	for len(p) > 0 {
 		n, data := p[0], p[1:]
 		// invalid frame, abort

--- a/cobs_test.go
+++ b/cobs_test.go
@@ -388,3 +388,42 @@ func ExampleEncode() {
 	// Hello: [6 72 101 108 108 111]
 	// [6 72 101 108 108 111]: Hello
 }
+
+func benchmarkEncode(i int, b *testing.B) {
+	data := make([]byte, i)
+	for i := range data {
+		data[i] = byte(i % 255)
+	}
+	data[len(data)-1] = 0 // zero-terminate input
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Encode(data)
+	}
+}
+
+func benchmarkDecode(i int, b *testing.B) {
+	data := make([]byte, i)
+	for i := range data {
+		data[i] = byte(i % 255)
+	}
+	data[len(data)-1] = 0 // zero-terminate input
+	enc := Encode(data)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Decode(enc)
+	}
+}
+
+func BenchmarkCobs(b *testing.B) {
+	cases := []int{32, 256, 1024, 4096}
+	for _, c := range cases {
+		b.Run(fmt.Sprintf("%d/Encode", c), func(b *testing.B) {
+			benchmarkEncode(c, b)
+		})
+		b.Run(fmt.Sprintf("%d/Decode", c), func(b *testing.B) {
+			benchmarkDecode(c, b)
+		})
+	}
+}


### PR DESCRIPTION
Thanks for a great package. I've been using this successfully many times.

We have been working on optimizing some software using this package and while profiling we noticed that it cobs.Encode/Decode uses a lot of time on allocating memory.  This PR improves the performance on Encode/Decode by preallocating the output buffers leading to much less memory allocation while running. This is most noticeable when encoding larger payloads.

Benchmark before:
```
$ go test -bench=. --benchmem
goos: linux
goarch: amd64
pkg: github.com/dim13/cobs
cpu: Intel(R) Core(TM) Ultra 9 185H
BenchmarkCobs/32/Encode-22         	17362496	        72.44 ns/op	      40 B/op	       2 allocs/op
BenchmarkCobs/32/Decode-22         	29137506	        40.76 ns/op	      40 B/op	       2 allocs/op
BenchmarkCobs/256/Encode-22        	 2756058	       401.2 ns/op	     776 B/op	       3 allocs/op
BenchmarkCobs/256/Decode-22        	18218660	        65.89 ns/op	     264 B/op	       2 allocs/op
BenchmarkCobs/1024/Encode-22       	  723136	      1687 ns/op	    3080 B/op	       5 allocs/op
BenchmarkCobs/1024/Decode-22       	 2752242	       455.7 ns/op	    3080 B/op	       5 allocs/op
BenchmarkCobs/4096/Encode-22       	  134398	      8721 ns/op	   17672 B/op	       9 allocs/op
BenchmarkCobs/4096/Decode-22       	  673791	      1764 ns/op	   12296 B/op	       8 allocs/op
PASS
ok  	github.com/dim13/cobs	10.792s
```

And after:

```
$ go test -bench=. --benchmem
goos: linux
goarch: amd64
pkg: github.com/dim13/cobs
cpu: Intel(R) Core(TM) Ultra 9 185H
BenchmarkCobs/32/Encode-22         	21400770	        53.49 ns/op	      32 B/op	       1 allocs/op
BenchmarkCobs/32/Decode-22         	162552748	         7.383 ns/op	       0 B/op	       0 allocs/op
BenchmarkCobs/256/Encode-22        	 4238409	       280.2 ns/op	     288 B/op	       1 allocs/op
BenchmarkCobs/256/Decode-22        	19978677	        54.38 ns/op	     288 B/op	       1 allocs/op
BenchmarkCobs/1024/Encode-22       	 1000000	      1211 ns/op	    1152 B/op	       1 allocs/op
BenchmarkCobs/1024/Decode-22       	 6245422	       183.0 ns/op	    1152 B/op	       1 allocs/op
BenchmarkCobs/4096/Encode-22       	  235732	      4596 ns/op	    4864 B/op	       1 allocs/op
BenchmarkCobs/4096/Decode-22       	 2016283	       614.8 ns/op	    4864 B/op	       1 allocs/op
PASS
ok  	github.com/dim13/cobs	11.339s
```

Short summary of this is that:
- 32 byte encode is 1.2x faster (21400770/17362496)
- 4096 byte encode is 2.9x faster (2016283/673791)
- 32 byte decode is 5.5x faster
- 4096 byte decode is 2.9x faster
